### PR TITLE
Fix issue #12: auto-label-issue を消す

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -19,22 +19,6 @@ permissions:
   issues: write
 
 jobs:
-  auto-label-issue:
-    if: github.event_name == 'issues' && github.event.action == 'opened'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Add fix-me label to new issues
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['fix-me']
-            });
-
   call-openhands-resolver:
     uses: All-Hands-AI/OpenHands/.github/workflows/openhands-resolver.yml@main
     with:


### PR DESCRIPTION
This pull request fixes #12.

The issue was to remove the "auto-label-issue" step from the GitHub Actions workflow file `openhands-resolver.yml`. The provided git patch shows that the entire job block for "auto-label-issue" has been deleted, which includes the condition, the runner specification, and the steps that added a "fix-me" label to new issues. This change directly addresses the issue description by removing the specified step, and thus, the issue has been successfully resolved. The expected impact is that new issues will no longer automatically receive the "fix-me" label, as the automation for this task has been removed.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌