### PR TITLE
Fix issue #16: OpenHands の起動タイミング変更

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -3,15 +3,13 @@ name: Resolve Issue with OpenHands
 
 "on":
   issues:
-    types: [opened, labeled]
-  pull_request:
     types: [labeled]
+  pull_request:
+    types: [assigned]
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  pull_request_review:
-    types: [submitted]
 
 permissions:
   contents: write
@@ -20,6 +18,10 @@ permissions:
 
 jobs:
   call-openhands-resolver:
+    if: |
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'fix-me') ||
+      (github.event_name == 'pull_request' && github.event.action == 'assigned') ||
+      ((github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && contains(github.event.comment.body, vars.OPENHANDS_MACRO || '@openhands-agent'))
     uses: All-Hands-AI/OpenHands/.github/workflows/openhands-resolver.yml@main
     with:
       macro: ${{ vars.OPENHANDS_MACRO || '@openhands-agent' }}


### PR DESCRIPTION
This pull request fixes #16.

The changes in the workflow configuration restrict the trigger events for the OpenHands GitHub Action to exactly the scenarios described in the issue. Specifically: (1) For issues, the workflow now only triggers when a label is added, and the job further checks that the label is "fix-me". (2) For pull requests, the workflow only triggers when a PR is assigned. (3) For both issue comments and pull request review comments, the workflow only triggers if the comment contains the OpenHands macro or "@openhands-agent", which covers the requirement to trigger on mentions. The previous triggers for issue creation, PR changes, and other PR review events have been removed, preventing unnecessary runs. Therefore, the changes directly address the problem of excessive workflow runs and ensure the action only runs at the specified times.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌