### PR TITLE
Fix issue #18: README の最新化

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ OpenHands を使用して Issue から自動的に Pull Request を作成する�
 
 ## 機能
 
-このリポジトリには、Issue が作成されたりラベルが付けられたりした際に、OpenHands AI エージェントが自動的に Pull Request を作成する GitHub Actions ワークフローが含まれています。
+このリポジトリには、OpenHands AI エージェントが自動的に Issue を分析し、Pull Request を作成する GitHub Actions ワークフローが含まれています。
+
+GitHub Actions のワークフローは [All-Hands-AI/OpenHands](https://github.com/All-Hands-AI/OpenHands) の reusable workflow を呼び出す形で構成されています。
+**2025年6月現在の OpenHands GitHub Actions の使い方に合わせて README を最新化しています。**
+
 
 ## セットアップ
 
@@ -19,25 +23,26 @@ OpenHands を使用して Issue から自動的に Pull Request を作成する�
 - `LLM_BASE_URL`: カスタム LLM ベース URL
 
 ### オプショナル変数
-- `OPENHANDS_MACRO`: トリガーマクロ (デフォルト: `@openhands-agent`)
-- `OPENHANDS_MAX_ITER`: 最大イテレーション数 (デフォルト: 50)
+- `OPENHANDS_MACRO`: トリガーマクロ（デフォルト: `@openhands-agent`）
+- `OPENHANDS_MAX_ITER`: 最大イテレーション数（デフォルト: 50）
 - `OPENHANDS_BASE_CONTAINER_IMAGE`: ベースコンテナイメージ
-- `LLM_MODEL`: 使用するLLMモデル (デフォルト: `anthropic/claude-sonnet-4-20250514`)
-- `TARGET_BRANCH`: ターゲットブランチ (デフォルト: `main`)
-- `TARGET_RUNNER`: ランナー指定
+- `LLM_MODEL`: 使用する LLM モデル（デフォルト: `anthropic/claude-sonnet-4-20250514`）
+- `TARGET_BRANCH`: ターゲットブランチ（デフォルト: `main`）
+- `TARGET_RUNNER`: 実行ランナー（必要に応じて指定）
 
 ## 使い方
 
 1. Issue を作成する
-2. システムが自動的に `fix-me` ラベルを追加します
+2. 必要に応じて `fix-me` ラベルを手動で付与する
 3. OpenHands エージェントが自動的に Issue を分析し、解決策を実装した Pull Request を作成します
-4. コメントで `@openhands-agent` を使用して追加の指示を出すことも可能です
+4. Issue や Pull Request のコメントで `@openhands-agent`（または `OPENHANDS_MACRO` で指定したマクロ）を使って追加指示を出すことも可能です
 
 ## トリガー
 
 ワークフローは以下のイベントでトリガーされます：
-- Issue が開かれた時 (`opened`) - 自動的に `fix-me` ラベルが追加されます
-- Issue にラベルが付けられた時 (`labeled`) - `fix-me` ラベルが必要です
-- Pull Request にラベルが付けられた時
-- Issue や Pull Request にコメントが作成された時
-- Pull Request レビューが提出された時
+- Issue に `fix-me` ラベルが付与された時
+- Pull Request がアサインされた時
+- Issue や Pull Request にコメントが作成され、`@openhands-agent`（または `OPENHANDS_MACRO` で指定したマクロ）が含まれている時
+- Pull Request レビューコメントに `@openhands-agent`（または `OPENHANDS_MACRO` で指定したマクロ）が含まれている時
+
+> 以前の「Issue 作成時に自動で `fix-me` ラベルを付与」や「PR にラベルが付いた時」などの挙動は、現在のワークフローでは行われません。必要に応じてラベル付与やマクロコメントを手動で行ってください。


### PR DESCRIPTION
This pull request fixes #18.

The issue requested updating the README to reflect changes in how OpenHands GitHub Actions are used. The changes in the PR update the README to describe the new workflow: it now explains that the workflow uses a reusable workflow from All-Hands-AI/OpenHands, clarifies that the `fix-me` label must be added manually (rather than being added automatically), and updates the list of triggers and environment variables to match the current behavior. It also adds a note that previous automatic behaviors (like auto-labeling on issue creation) are no longer present and must be done manually. These updates accurately document the new usage and behavior of the GitHub Actions workflow, directly addressing the issue described.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌